### PR TITLE
feat: add model parameter for LLM selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ jobs:
 | `version`                | String | false    | `"latest"` | Version of the zencoder to use                                     |
 | `agent`                  | String | false    | `""`       | Alias of the agent to run (will run default agent if not provided) |
 | `base_path`              | String | false    | `"."`      | Base path to run agent from (should be repository root)            |
+| `model`                  | String | false    | `"default"`| LLM model to use (e.g., `opus-4-5`, `sonnet-4`, `gemini-25-pro`). Use `default` for server default. |
 
 [release]: https://github.com/zencoderai/zen-agents-action/releases/latest
 [release-img]: https://img.shields.io/github/release/zencoderai/zen-agents-action.svg?logo=github

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: "Version of the zencoder cli to use"
     required: false
     default: latest
+  model:
+    description: "LLM model to use (e.g., opus-4-5, sonnet-4, gemini-25-pro). Use 'default' for server default."
+    required: false
+    default: "default"
 
 runs:
   using: "composite"
@@ -43,8 +47,13 @@ runs:
         PROMPT: "${{ inputs.prompt }}"
         AGENT: "${{ inputs.agent }}"
         BASE_PATH: "${{ inputs.base_path }}"
+        MODEL: "${{ inputs.model }}"
         GITHUB_TOKEN: ${{ inputs.github_token }}
         CLIENT_ID: ${{ inputs.zencoder_client_id }}
         CLIENT_SECRET: ${{ inputs.zencoder_client_secret }}
       run: |
-        ./zencoder --base-path "$BASE_PATH" --agent "$AGENT" --prompt "$PROMPT" --autonomous
+        MODEL_ARG=""
+        if [ -n "$MODEL" ] && [ "$MODEL" != "default" ]; then
+          MODEL_ARG="--model $MODEL"
+        fi
+        ./zencoder --base-path "$BASE_PATH" --agent "$AGENT" $MODEL_ARG --prompt "$PROMPT" --autonomous


### PR DESCRIPTION
## Summary
- Add optional `model` input parameter to allow specifying which LLM model to use
- Supports models like `opus-4-5`, `sonnet-4`, `gemini-25-pro`
- Backward compatible - existing workflows without `model` parameter continue to work unchanged (uses server default)

## Changes
- `action.yml`: Add `model` input with `default` as default value, pass `--model` flag to CLI only when not "default"
- `README.md`: Document new parameter in inputs table

## Usage Example
```yaml
- name: Running Zencoder Agent
  uses: zencoderai/zen-agents-action@main
  with:
    prompt: "Review this PR"
    model: "opus-4-5"  # Optional - uses server default if not specified
    zencoder_client_id: "${{ secrets.ZENCODER_CLIENT_ID }}"
    zencoder_client_secret: "${{ secrets.ZENCODER_CLIENT_SECRET }}"
    github_token: "${{ secrets.GITHUB_TOKEN }}"
```

## Test plan
- [ ] Test without model parameter (should use server default)
- [ ] Test with model="default" (should use server default)
- [ ] Test with model="opus-4-5" (should pass --model opus-4-5 to CLI)