### PR TITLE
Make client credentials optional and add API key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 
 ## Authentication
 
-To get Zencoder client id and secret go to the https://auth.zencoder.ai/profile and click on **Settings** -> **Personal Tokens**.
+Generate an API key at https://auth.zencoder.ai/api-keys and pass it as `zencoder_api_key`.
+
+> **Note:** `zencoder_client_id` and `zencoder_client_secret` are deprecated and kept for backwards compatibility only. Use `zencoder_api_key` for new integrations.
 
 ## Workflow examples
 
@@ -31,6 +33,7 @@ jobs:
         uses: zencoderai/zen-agents-action@main
         with:
           prompt: "Please review the pull request with number ${{ github.event.pull_request.number }} and add comment to it. Please address only the serious issues, not the minor ones. If you didn't find any serious issues, please write 'Looks good to me!'."
+          zencoder_api_key: "${{ secrets.ZENCODER_API_KEY }}"
           zencoder_client_id: "${{ secrets.ZENCODER_CLIENT_ID }}"
           zencoder_client_secret: "${{ secrets.ZENCODER_CLIENT_SECRET }}"
           github_token: "${{ secrets.GITHUB_TOKEN }}"
@@ -65,6 +68,7 @@ jobs:
         with:
           prompt: "${{ inputs.prompt }}"
           agent: "${{ inputs.agent }}"
+          zencoder_api_key: "${{ secrets.ZENCODER_API_KEY }}"
           zencoder_client_id: "${{ secrets.ZENCODER_CLIENT_ID }}"
           zencoder_client_secret: "${{ secrets.ZENCODER_CLIENT_SECRET }}"
           github_token: "${{ secrets.GITHUB_TOKEN }}"
@@ -74,8 +78,9 @@ jobs:
 
 | Name                     | Type   | Required | Default    | Description                                                        |
 | ------------------------ | ------ | -------- | ---------- | ------------------------------------------------------------------ |
-| `zencoder_client_id`     | String | true     |            | Zencoder client id for authentication                              |
-| `zencoder_client_secret` | String | true     |            | Zencoder client secret for authentication                          |
+| `zencoder_api_key`       | String | false    |            | Zencoder API key for authentication                                |
+| `zencoder_client_id`     | String | false    |            | Zencoder client id (deprecated, use `zencoder_api_key`)            |
+| `zencoder_client_secret` | String | false    |            | Zencoder client secret (deprecated, use `zencoder_api_key`)        |
 | `github_token`           | String | true     |            | GitHub token used by the action to access GitHub APIs              |
 | `prompt`                 | String | true     |            | The input prompt for the Agent                                     |
 | `version`                | String | false    | `"latest"` | Version of the zencoder to use                                     |

--- a/action.yml
+++ b/action.yml
@@ -14,10 +14,16 @@ inputs:
     default: "."
   zencoder_client_id:
     description: "Client ID for Zencoder API"
-    required: true
+    required: false
+    default: ""
   zencoder_client_secret:
     description: "Client Secret for Zencoder API"
-    required: true
+    required: false
+    default: ""
+  zencoder_api_key:
+    description: "API key for Zencoder API"
+    required: false
+    default: ""
   github_token:
     description: "GitHub token used by the action to access GitHub APIs"
     required: true
@@ -76,6 +82,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github_token }}
         CLIENT_ID: ${{ inputs.zencoder_client_id }}
         CLIENT_SECRET: ${{ inputs.zencoder_client_secret }}
+        ZENCODER_API_KEY: ${{ inputs.zencoder_api_key }}
       run: |
         MODEL_ARG=""
         if [ -n "$MODEL" ] && [ "$MODEL" != "default" ]; then

--- a/docs/BITBUCKET_INTEGRATION_GUIDE.md
+++ b/docs/BITBUCKET_INTEGRATION_GUIDE.md
@@ -16,7 +16,7 @@ This guide provides step-by-step instructions for integrating the Autonomous Age
 Before starting the integration, ensure you have:
 
 - A Bitbucket account with repository access
-- Zencoder client credentials (CLIENT_ID and CLIENT_SECRET)
+- Zencoder API key (or legacy client credentials)
 - Repository with write permissions
 - Basic understanding of environment variables and YAML configuration
 
@@ -75,8 +75,9 @@ For organizations managing multiple repositories:
    
    | Variable Name | Value | Secured |
    |--------------|-------|---------|
-   | `ZENCODER_CLIENT_ID` | Your client ID | No |
-   | `ZENCODER_CLIENT_SECRET` | Your client secret | Yes |
+   | `ZENCODER_API_KEY` | Your API key | Yes |
+   | `ZENCODER_CLIENT_ID` | Your client ID (deprecated) | No |
+   | `ZENCODER_CLIENT_SECRET` | Your client secret (deprecated) | Yes |
    | `ZENCODER_BITBUCKET_TOKEN` | Your Bitbucket token | Yes |
 
 #### Repository-Level Configuration (Alternative)

--- a/docs/GITHUB_INTEGRATION_GUIDE.md
+++ b/docs/GITHUB_INTEGRATION_GUIDE.md
@@ -16,7 +16,7 @@ This guide provides step-by-step instructions for integrating the Autonomous Age
 Before starting the integration, ensure you have:
 
 - A GitHub account with repository access
-- Zencoder client credentials (CLIENT_ID and CLIENT_SECRET)
+- Zencoder API key (or legacy client credentials)
 - Repository with write permissions
 - Basic understanding of GitHub Actions and YAML configuration
 
@@ -65,11 +65,12 @@ For managing multiple repositories:
 2. Click **New organization secret**
 3. Add the following secrets:
    
-   | Secret Name              | Value              | Description                     |
-   |--------------------------|--------------------|---------------------------------|
-   | `ZENCODER_CLIENT_ID`     | Your client ID     | Zencoder API client ID          |
-   | `ZENCODER_CLIENT_SECRET` | Your client secret | Zencoder API client secret      |
-   | `CICD_TOKEN`             | Your GitHub PAT    | Token with elevated permissions |
+   | Secret Name              | Value              | Description                                      |
+   |--------------------------|--------------------|-------------------------------------------------|
+   | `ZENCODER_API_KEY`       | Your API key       | Zencoder API key (generate at auth.zencoder.ai/api-keys) |
+   | `ZENCODER_CLIENT_ID`     | Your client ID     | Zencoder client ID (deprecated)                 |
+   | `ZENCODER_CLIENT_SECRET` | Your client secret | Zencoder client secret (deprecated)             |
+   | `CICD_TOKEN`             | Your GitHub PAT    | Token with elevated permissions                 |
 
 4. Select which repositories can access these secrets
 

--- a/docs/bitbucket-pipelines.yml
+++ b/docs/bitbucket-pipelines.yml
@@ -34,6 +34,7 @@ definitions:
             }
           - chmod +x zencoder
           - echo "Successfully installed and verified zencoder"
+          - export ZENCODER_API_KEY="${ZENCODER_API_KEY}"
           - export CLIENT_ID="${ZENCODER_CLIENT_ID}"
           - export CLIENT_SECRET="${ZENCODER_CLIENT_SECRET}"
           - export BITBUCKET_TOKEN="${ZENCODER_BITBUCKET_TOKEN}"
@@ -80,6 +81,7 @@ definitions:
             }
           - chmod +x zencoder
           - echo "Successfully installed and verified zencoder"
+          - export ZENCODER_API_KEY="${ZENCODER_API_KEY}"
           - export CLIENT_ID="${ZENCODER_CLIENT_ID}"
           - export CLIENT_SECRET="${ZENCODER_CLIENT_SECRET}"
           - export BITBUCKET_TOKEN="${ZENCODER_BITBUCKET_TOKEN}"

--- a/docs/gitlab-ci-integration.md
+++ b/docs/gitlab-ci-integration.md
@@ -12,8 +12,9 @@ The GitLab CI/CD integration allows you to run AI-powered agents on your reposit
 
 In your GitLab project, navigate to **Settings > CI/CD > Variables** and add the following variables:
 
-- `ZENCODER_CLIENT_ID`: Your Zencoder API client ID
-- `ZENCODER_CLIENT_SECRET`: Your Zencoder API client secret (mark as protected and masked)
+- `ZENCODER_API_KEY`: Your Zencoder API key — generate at https://auth.zencoder.ai/api-keys (mark as protected and masked)
+- `ZENCODER_CLIENT_ID`: Your Zencoder API client ID (deprecated)
+- `ZENCODER_CLIENT_SECRET`: Your Zencoder API client secret (deprecated, mark as protected and masked)
 - `ZENCODER_GITLAB_TOKEN`: GitLab access token with API permissions (mark as protected and masked)
 
 Make sure to set the **Minimum role to use pipeline variables** setting to the role of the person configuring the pipeline.
@@ -63,8 +64,9 @@ The following environment variables can be configured:
 
 | Variable                 | Description | Required |
 |--------------------------|-------------|----------|
-| `ZENCODER_CLIENT_ID`     | Your Zencoder API client ID | Yes |
-| `ZENCODER_CLIENT_SECRET` | Your Zencoder API client secret | Yes |
+| `ZENCODER_API_KEY`       | Your Zencoder API key | Yes |
+| `ZENCODER_CLIENT_ID`     | Your Zencoder API client ID (deprecated) | No |
+| `ZENCODER_CLIENT_SECRET` | Your Zencoder API client secret (deprecated) | No |
 | `ZENCODER_GITLAB_TOKEN`  | GitLab access token with API permissions | Yes |
 | `agent`                  | Specific agent to use (optional) | No |
 | `VERSION`                | Zencoder binary version to download | No (defaults to "latest") |

--- a/docs/gitlab-ci.yml
+++ b/docs/gitlab-ci.yml
@@ -39,6 +39,7 @@ stages:
       }
     - chmod +x zencoder
     - echo "Successfully installed and verified zencoder"
+    - export ZENCODER_API_KEY="${ZENCODER_API_KEY}"
     - export CLIENT_ID="${ZENCODER_CLIENT_ID}"
     - export CLIENT_SECRET="${ZENCODER_CLIENT_SECRET}"
     - export GITLAB_TOKEN="${ZENCODER_GITLAB_TOKEN}"
@@ -122,6 +123,7 @@ zencoder-mr-review:
       }
     - chmod +x zencoder
     - echo "Successfully installed and verified zencoder"
+    - export ZENCODER_API_KEY="${ZENCODER_API_KEY}"
     - export CLIENT_ID="${ZENCODER_CLIENT_ID}"
     - export CLIENT_SECRET="${ZENCODER_CLIENT_SECRET}"
     - export GITLAB_TOKEN="${ZENCODER_GITLAB_TOKEN}"

--- a/docs/pr-review.yaml
+++ b/docs/pr-review.yaml
@@ -22,6 +22,7 @@ jobs:
         uses: zencoderai/zen-agents-action@main
         with:
           prompt: "Review pull request #${{ github.event.pull_request.number }} and add comments. Focus on serious issues only."
+          zencoder_api_key: "${{ secrets.ZENCODER_API_KEY }}"
           zencoder_client_id: "${{ secrets.ZENCODER_CLIENT_ID }}"
           zencoder_client_secret: "${{ secrets.ZENCODER_CLIENT_SECRET }}"
           github_token: "${{ secrets.CICD_TOKEN }}"

--- a/docs/zencoder-agent.yaml
+++ b/docs/zencoder-agent.yaml
@@ -25,6 +25,7 @@ jobs:
         with:
           prompt: "${{ inputs.prompt }}"
           agent: "${{ inputs.agent }}"
+          zencoder_api_key: "${{ secrets.ZENCODER_API_KEY }}"
           zencoder_client_id: "${{ secrets.ZENCODER_CLIENT_ID }}"
           zencoder_client_secret: "${{ secrets.ZENCODER_CLIENT_SECRET }}"
           github_token: "${{ secrets.CICD_TOKEN }}"


### PR DESCRIPTION
## Summary
- Make `zencoder_client_id` and `zencoder_client_secret` optional inputs (previously required)
- Add new optional `zencoder_api_key` input, exposed as `ZENCODER_API_KEY` env var to the CLI

## Test plan
- [ ] Verify action works with client ID + secret (existing auth flow)
- [ ] Verify action works with `zencoder_api_key` alone
- [ ] Verify action fails gracefully when no auth params are provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)